### PR TITLE
make node path use process.execPath to fix Windows issue

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const exec = require('child_process').exec;
 // this is from the env of npm, not node
-const nodePath = process.env.NODE;
+const nodePath = process.execPath;
 const version = process.versions.v8;
 const tmpfile = path.join(__dirname, version+'.flags.json');
 


### PR DESCRIPTION
Fixes #7 

Currently attempts to install v8flags fail on Windows with the error:

C:...\npm\node_modules\v8flags\fetch.js:14
      throw new Error(execErr);
            ^
Error: Error: Command failed: '"C:\Program Files\nodejs\"' is not recognized as
an internal or external command,
operable program or batch file.

```
at C:\Users\mklein\AppData\Roaming\npm\node_modules\v8flags\fetch.js:14:13
at ChildProcess.exithandler (child_process.js:652:7)
at ChildProcess.emit (events.js:98:17)
at maybeClose (child_process.js:756:16)
at Socket.<anonymous> (child_process.js:969:11)
at Socket.emit (events.js:95:17)
at Pipe.close (net.js:465:12)
```

npm ERR! v8flags@1.0.4 install: `node fetch.js`
npm ERR! Exit status 8
npm ERR!
npm ERR! Failed at the v8flags@1.0.4 install script.
npm ERR! This is most likely a problem with the v8flags package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node fetch.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls v8flags
npm ERR! There is likely additional logging output above.
npm ERR! System Windows_NT 6.1.7601
npm ERR! command "C:\Program Files\nodejs\\node.exe" "C:\Program Files\nod
ejs\node_modules\npm\bin\npm-cli.js" "install" "-g" "v8flags"
npm ERR! cwd C:\
npm ERR! node -v v0.10.33
npm ERR! npm -v 1.4.28
npm ERR! code ELIFECYCLE
npm ERR! not ok code 0

The reason for this is that the node path is used, without the executable itself -- so of course it can't be executed. A simple fix which I believe should work everywhere is using "process.execPath" instead of "process.env.NODE".
