### PR TITLE
Attempt to cache using a temp file if home is unwriteable

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,17 @@ function fail (err) {
 
 function openConfig (cb) {
   var userHome = require('user-home');
-  var configpath = path.join(userHome || os.tmpdir(), configfile);
-  var content;
+  if (!userHome) {
+    return tryOpenConfig(path.join(os.tmpdir(), configfile), cb);
+  }
+
+  tryOpenConfig(path.join(userHome, configfile), function (err, fd) {
+    if (err) return tryOpenConfig(path.join(os.tmpdir(), configfile), cb);
+    return cb(null, fd);
+  });
+}
+
+function tryOpenConfig (configpath, cb) {
   try {
     // if the config file is valid, it should be json and therefore
     // node should be able to require it directly. if this doesn't


### PR DESCRIPTION
This helps alleviate #22 and #19, by attempting to use a temporary file to cache if the home directory is unwriteable. Previously, a temporary file was only used if the home directory could not be found.