### PR TITLE
Stop polluting globals inside callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function tryOpenConfig (configpath, cb) {
     // if the config file is valid, it should be json and therefore
     // node should be able to require it directly. if this doesn't
     // throw, we're done!
-    content = require(configpath);
+    var content = require(configpath);
     process.nextTick(function () {
       cb(null, content);
     });


### PR DESCRIPTION
Background: I'm using Pug templates inside of Gulp. One template looks like this:

```pug
if content
  h1 #{content}
```

If I don't define `content` when I render the template, it fallbacks to the `global` object, which was polluted with the V8 flags.

A simple `var` stops that.

![gif](
https://68.media.tumblr.com/7e0bb92f539a5127309fd12395da20a7/tumblr_na8rhksl3Z1twbpheo2_400.gif)