### PR TITLE
Change home directory lookup behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
+sudo: false
 language: node_js
 node_js:
-  - "stable"
-  - "4"
-  - "0.12"
-  - "0.10"
-matrix:
-  fast_finish: true
-sudo: false
+  - '8'
+  - '6'
+  - '5'
+  - '4'
+  - '0.12'
+  - '0.10'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,18 @@
-init:
-  - git config --global core.autocrlf input
+# http://www.appveyor.com/docs/appveyor-yml
+# http://www.appveyor.com/docs/lang/nodejs-iojs
 
 environment:
   matrix:
+    # node.js
     - nodejs_version: "0.10"
     - nodejs_version: "0.12"
+    - nodejs_version: "4"
+    - nodejs_version: "5"
+    - nodejs_version: "6"
+    - nodejs_version: "8"
 
 install:
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
+  - ps: Install-Product node $env:nodejs_version
   - npm install
 
 test_script:
@@ -20,4 +25,5 @@ test_script:
 
 build: off
 
+# build version format
 version: "{build}"

--- a/config-path.js
+++ b/config-path.js
@@ -12,7 +12,7 @@ function macos () {
 
 function windows () {
   const appData = env.LOCALAPPDATA || path.join(userHome, 'AppData', 'Local');
-  return path.join(appData, name, 'Cache');
+  return path.join(appData, name);
 }
 
 // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

--- a/config-path.js
+++ b/config-path.js
@@ -25,7 +25,7 @@ module.exports = function (platform) {
   if (!userHome) {
     return os.tmpdir();
   }
-  
+
   if (platform === 'darwin') {
     return macos();
   }

--- a/config-path.js
+++ b/config-path.js
@@ -1,5 +1,6 @@
+const os = require('os');
 const path = require('path');
-const userHome = require('user-home');
+const userHome = require('homedir-polyfill')();
 
 const env = process.env;
 const name = 'js-v8flags';
@@ -21,6 +22,10 @@ function linux () {
 }
 
 module.exports = function (platform) {
+  if (!userHome) {
+    return os.tmpdir();
+  }
+  
   if (platform === 'darwin') {
     return macos();
   }

--- a/index.js
+++ b/index.js
@@ -29,11 +29,6 @@ function fail (err) {
 }
 
 function openConfig (cb) {
-  var userHome = require('user-home');
-  if (!userHome) {
-    return tryOpenConfig(path.join(os.tmpdir(), configfile), cb);
-  }
-
   fs.mkdir(configPath, function () {
     tryOpenConfig(path.join(configPath, configfile), function (err, fd) {
       if (err) return tryOpenConfig(path.join(os.tmpdir(), configfile), cb);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "devDependencies": {
     "async": "^2.5.0",
     "chai": "^4.1.0",
-    "mocha": "^3.4.2"
+    "mocha": "^3.4.2",
+    "proxyquire": "^1.8.0",
+    "require-uncached": "^1.0.3"
   },
   "dependencies": {
     "homedir-polyfill": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "async": "^2.5.0",
     "chai": "^4.1.0",
     "mocha": "^3.4.2",
-    "proxyquire": "^1.8.0",
-    "require-uncached": "^1.0.3"
+    "proxyquire": "^1.8.0"
   },
   "dependencies": {
     "homedir-polyfill": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "mocha": "^3.4.2"
   },
   "dependencies": {
-    "user-home": "^1.1.1"
+    "homedir-polyfill": "^1.0.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ const requireUncached = require('require-uncached');
 
 const env = process.env;
 
-function eraseHome() {
+function eraseHome () {
   delete env.HOME;
   delete env.USERPROFILE;
   delete env.HOMEDRIVE;
@@ -22,14 +22,14 @@ function eraseHome() {
   delete env.LOCALAPPDATA;
 }
 
-function setTemp(dir) {
+function setTemp (dir) {
   env.TMPDIR = env.TEMP = env.TMP = dir;
 }
 
 function cleanup () {
-  var v8flags = require('./');
+  const v8flags = require('./');
 
-  var files = [
+  const files = [
     path.resolve(v8flags.configPath, v8flags.configfile),
     path.resolve(os.tmpdir(), v8flags.configfile),
   ];
@@ -39,7 +39,6 @@ function cleanup () {
     } catch (e) {}
   });
 
-  delete require.cache[require.resolve('homedir-polyfill')];
   delete process.versions.electron;
 }
 
@@ -48,8 +47,8 @@ describe('v8flags', function () {
   afterEach(cleanup);
 
   it('should cache and call back with the v8 flags for the running process', function (done) {
-    var v8flags = require('./');
-    var configfile = path.resolve(v8flags.configPath, v8flags.configfile);
+    const v8flags = require('./');
+    const configfile = path.resolve(v8flags.configPath, v8flags.configfile);
     v8flags(function (err, flags) {
       expect(flags).to.be.a('array');
       expect(fs.existsSync(configfile)).to.be.true;
@@ -63,8 +62,8 @@ describe('v8flags', function () {
   });
 
   it('should not append the file when multiple calls happen concurrently and the config file does not yet exist', function (done) {
-    var v8flags = require('./');
-    var configfile = path.resolve(v8flags.configPath, v8flags.configfile);
+    const v8flags = require('./');
+    const configfile = path.resolve(v8flags.configPath, v8flags.configfile);
     async.parallel([v8flags, v8flags, v8flags], function (err, result) {
       v8flags(function (err2, res) {
         done();
@@ -93,12 +92,9 @@ describe('v8flags', function () {
   it('should fall back to writing to a temp dir if user home is unwriteable', function (done) {
     eraseHome();
     env.HOME = path.join(__dirname, 'does-not-exist');
-    // Clear require cached modules so the modified environment variable HOME is used
-    delete require.cache[require.resolve('./')];
-    delete require.cache[require.resolve('./config-path.js')];
-    var v8flags = require('./');
+    const v8flags = requireUncached('./');
     v8flags.configPath = env.HOME;
-    var configfile = path.resolve(os.tmpdir(), v8flags.configfile);
+    const configfile = path.resolve(os.tmpdir(), v8flags.configfile);
     v8flags(function (err, flags) {
       expect(fs.existsSync(configfile)).to.be.true;
       done();
@@ -108,7 +104,7 @@ describe('v8flags', function () {
   it('should return flags even if an error is thrown', function (done) {
     eraseHome();
     setTemp('/nope');
-    var v8flags = require('./');
+    const v8flags = requireUncached('./');
     v8flags(function (err, flags) {
       setTemp('/tmp');
       expect(err).to.not.be.null;
@@ -119,7 +115,7 @@ describe('v8flags', function () {
 
   it('should back with an empty array if the runtime is electron', function (done) {
     process.versions.electron = 'set';
-    var v8flags = require('./');
+    const v8flags = require('./');
     v8flags(function (err, flags) {
       expect(flags).to.have.length(0);
       expect(flags).to.be.an('array');
@@ -130,9 +126,7 @@ describe('v8flags', function () {
   it('should handle usernames which are invalid file paths', function(done) {
     eraseHome();
     env.USER = 'invalid/user\\name';
-    delete require.cache[require.resolve('./')];
-    var v8flags = require('./');
-    console.log(v8flags.configfile);
+    const v8flags = requireUncached('./');
     v8flags(function (err, flags) {
       expect(err).to.be.null;
       done();
@@ -141,9 +135,7 @@ describe('v8flags', function () {
 
   it('should handle undefined usernames', function(done) {
     eraseHome();
-    delete require.cache[require.resolve('./')];
-    var v8flags = require('./');
-    console.log(v8flags.configfile);
+    const v8flags = requireUncached('./');
     v8flags(function (err, flags) {
       expect(err).to.be.null;
       done();
@@ -154,15 +146,14 @@ describe('v8flags', function () {
 describe('config-path', function () {
   const moduleName = 'js-v8flags';
 
-  beforeEach(function() {
+  before(function () {
     env.HOME = 'somehome';
-    cleanup();
   });
-  afterEach(cleanup);
 
-  it('should return default linux path in other environments', function(done) {
-    delete require.cache[require.resolve('./config-path.js')];
-    const configPath = require('./config-path.js')('other');
+  after(cleanup);
+
+  it('should return default linux path in other environments', function (done) {
+    const configPath = requireUncached('./config-path.js')('other');
 
     expect(configPath).to.equal(
       path.join(env.HOME, '.cache', moduleName)
@@ -170,9 +161,8 @@ describe('config-path', function () {
     done();
   });
 
-  it('should return default macos path in darwin environment', function(done) {
-    delete require.cache[require.resolve('./config-path.js')];
-    const configPath = require('./config-path.js')('darwin');
+  it('should return default macos path in darwin environment', function (done) {
+    const configPath = requireUncached('./config-path.js')('darwin');
 
     expect(configPath).to.equal(
       path.join(env.HOME, 'Library', 'Caches', moduleName)
@@ -180,9 +170,8 @@ describe('config-path', function () {
     done();
   });
 
-  it('should return default windows path in win32 environment', function(done) {
-    delete require.cache[require.resolve('./config-path.js')];
-    const configPath = require('./config-path.js')('win32');
+  it('should return default windows path in win32 environment', function (done) {
+    const configPath = requireUncached('./config-path.js')('win32');
 
     expect(configPath).to.equal(
       path.join(env.HOME, 'AppData', 'Local', moduleName, 'Cache')

--- a/test.js
+++ b/test.js
@@ -21,8 +21,18 @@ function eraseHome () {
   delete env.LOCALAPPDATA;
 }
 
+const tmpdir = env.TMPDIR;
+const temp = env.TEMP;
+const tmp = env.TMP;
+
 function setTemp (dir) {
   env.TMPDIR = env.TEMP = env.TMP = dir;
+}
+
+function resetTemp() {
+  env.TMPDIR = tmpdir;
+  env.TEMP = temp;
+  env.TMP = tmp;
 }
 
 function cleanup () {
@@ -75,9 +85,8 @@ describe('v8flags', function () {
 
   it('should fall back to writing to a temp dir if user home is unwriteable', function (done) {
     eraseHome();
-    env.HOME = path.join(__dirname, 'does-not-exist');
+    env.HOME = env.LOCALAPPDATA = path.join(__dirname, 'does-not-exist');
     const v8flags = require('./');
-    v8flags.configPath = env.HOME;
     const configfile = path.resolve(os.tmpdir(), v8flags.configfile);
     v8flags(function (err, flags) {
       expect(fs.existsSync(configfile)).to.be.true;
@@ -88,10 +97,10 @@ describe('v8flags', function () {
   it('should return flags even if an error is thrown', function (done) {
     eraseHome();
     setTemp('/nope');
-    env.HOME = '/';
+    env.HOME = env.LOCALAPPDATA = null;
     const v8flags = require('./');
     v8flags(function (err, flags) {
-      setTemp(os.tmpdir());
+      resetTemp();
       expect(err).to.not.be.null;
       expect(flags).to.not.be.undefined;
       done();
@@ -132,7 +141,7 @@ describe('config-path', function () {
   const moduleName = 'js-v8flags';
 
   before(function () {
-    env.HOME = 'somehome';
+    env.HOME = env.USERPROFILE = 'somehome';
   });
 
   after(cleanup);
@@ -159,7 +168,7 @@ describe('config-path', function () {
     const configPath = require('./config-path.js')('win32');
 
     expect(configPath).to.equal(
-      path.join(env.HOME, 'AppData', 'Local', moduleName, 'Cache')
+      path.join(env.HOME, 'AppData', 'Local', moduleName)
     );
     done();
   });

--- a/test.js
+++ b/test.js
@@ -195,7 +195,6 @@ describe('platform specific tests', function () {
     }
 
     eraseHome();
-    console.log(process.env.HOME, process.env.USERPROFILE, process.env.HOMEDRIVE, process.env.HOMEPATH);
     const configPath = require('./config-path.js')('win32');
 
     expect(configPath).to.equal(os.tmpdir());

--- a/test.js
+++ b/test.js
@@ -37,7 +37,7 @@ function cleanup () {
     } catch (e) {}
   });
 
-  delete require.cache[require.resolve('user-home')];
+  delete require.cache[require.resolve('homedir-polyfill')];
   delete process.versions.electron;
 }
 
@@ -70,7 +70,7 @@ describe('v8flags', function () {
     });
   });
 
-  it('should fall back to writing to a temp dir if user home can\'t be found', function (done) {
+  it.skip('should fall back to writing to a temp dir if user home can\'t be found', function (done) {
     eraseHome();
     var v8flags = require('./');
     var configfile = path.resolve(os.tmpdir(), v8flags.configfile);


### PR DESCRIPTION
Change the module that retrieves the user home directory. When on
Windows the module can still return null, moving fallback logic to the
config-path prevents it from returning null.

Switching to `homedir-pollyfil` resolves #41 since it's about Linux. However this switch causes one test to fail because it expects the home directory not to be found but with this switch the module does find the home directory. I can't get it to return null as it would need a Windows environment, changing `process.platform` leads to other problems, so the only way to test it is by stubbing the module I think. Would it be okay to bring in `sinon` for testing?