### PR TITLE
Avoid using deprecated Buffer API on newer Node.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,18 @@ function getFlags (cb) {
 // write some json to a file descriptor. if this fails, call back
 // with both the error and the data that was meant to be written.
 function writeConfig (fd, flags, cb) {
-  var buf = new Buffer(JSON.stringify(flags));
+  var json = JSON.stringify(flags);
+  var buf;
+  if (Buffer.from && Buffer.from !== Uint8Array.from) {
+    // Node.js 4.5.0 or newer
+    buf = Buffer.from(json);
+  } else {
+    // Old Node.js versions
+    // The typeof safeguard below is mostly against accidental copy-pasting
+    // and code rewrite, it never happens as json is always a string here.
+    if (typeof json === 'number') throw new Error('Unexpected type number');
+    buf = new Buffer(json);
+  }
   return fs.write(fd, buf, 0, buf.length, 0 , function (writeErr) {
     fs.close(fd, function (closeErr) {
       var err = writeErr || closeErr;


### PR DESCRIPTION
This avoids using Buffer constructor API on newer Node.js versions.

To achieve that, `Buffer.from` presence is checked, with validation that it's not the same method as Uint8Array.from.

Also an additional type-guard is added in the fallback code path to ensure that typed numbers are never accidently fed into `new Buffer` input.

Given this module popularity and the fact that old Buffer constructor API was used in a single place, I decided to just feature-detect it in-place instead of pulling in polyfill deps.
Another way would be to just use `Buffer.from` and do `var Buffer = require('safe-buffer')`;

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Tracking:
https://github.com/nodejs/node/issues/19079