### PR TITLE
Allow using XDG_CACHE_HOME on non-linux platforms.

### DIFF
--- a/config-path.js
+++ b/config-path.js
@@ -26,6 +26,11 @@ module.exports = function (platform) {
     return os.tmpdir();
   }
 
+  // Non-linux users can also set this environment variable.
+  if (env.XDG_CACHE_HOME) {
+    return linux();
+  }
+
   if (platform === 'darwin') {
     return macos();
   }

--- a/test.js
+++ b/test.js
@@ -174,6 +174,21 @@ describe('config-path', function () {
     done();
   });
 
+  it('should return default linux path if XDG_CACHE_HOME is set', function (done) {
+    process.env.XDG_CACHE_HOME = path.join(env.HOME, '.local', 'cache');
+
+    const configPath = require('./config-path.js')('any');
+
+    expect(configPath).to.equal(
+      path.join(env.HOME, '.local', 'cache', moduleName)
+    );
+
+    delete process.env.XDG_CACHE_HOME;
+
+    done();
+  });
+
+
   it('should return fallback path when homedir is falsy', function (done) {
     const configPath = proxyquire('./config-path.js', {
       'homedir-polyfill': function () {

--- a/test.js
+++ b/test.js
@@ -174,13 +174,14 @@ describe('config-path', function () {
     done();
   });
 
-  it('should return default linux path if XDG_CACHE_HOME is set', function (done) {
-    process.env.XDG_CACHE_HOME = path.join(env.HOME, '.local', 'cache');
+  it('should return the specified path if XDG_CACHE_HOME is set', function (done) {
+    const cachePath = path.join(env.HOME, '.local', 'cache');
+    process.env.XDG_CACHE_HOME = cachePath;
 
     const configPath = require('./config-path.js')('any');
 
     expect(configPath).to.equal(
-      path.join(env.HOME, '.local', 'cache', moduleName)
+      path.join(cachePath, moduleName)
     );
 
     delete process.env.XDG_CACHE_HOME;


### PR DESCRIPTION
I'd like to be able to use XDG_CACHE_HOME on non-linux platforms (more specifically, macOS).

The XDG directory specification is primarily used on linux, but many tools don't actually care about the platform they're running on as to whether they accept that particular environment variable, so I'd like to propose a small change to `config-path.js` to have an early return of `linux()`, before the platform is taken into account.

This will allow me, (and hopefully others with the same environment variable), to keep their home directories clean of cached files, and localise them all to one place.