### PR TITLE
Fix regex used for parsing flag names

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function getFlags (cb) {
     if (execErr) {
       return cb(execErr);
     }
-    var flags = result.match(/\s\s--(\w+)/gm).map(function (match) {
+    var flags = result.match(/\s\s--(\w|-)+/gm).map(function (match) {
       return match.substring(2);
     }).filter(function (name) {
       return exclusions.indexOf(name) === -1;

--- a/test.js
+++ b/test.js
@@ -108,6 +108,18 @@ describe('v8flags', function () {
     });
   });
 
+  it('should return unique flags', function (done) {
+    const v8flags = require('./');
+    v8flags(function (err, foundFlags) {
+      const uniqueFlags = foundFlags.reduce(function (res, val) {
+        res[val] = true;
+        return res;
+      }, {});
+      expect(Object.keys(uniqueFlags)).to.have.lengthOf(foundFlags.length);
+      done();
+    });
+  });
+
   it('should back with an empty array if the runtime is electron', function (done) {
     process.versions.electron = 'set';
     const v8flags = require('./');


### PR DESCRIPTION
`v8flags()` currently gives me:
```
[ '--experimental',
  '--use',
  '--es',
  '--harmony',
  '--harmony',
  '--harmony',
  '--harmony',
  ... ]
```
Those are not really the flags for v8, and it messes `liftoff` and `gulp` and my own CLI since it returns a lot of irrelevant v8 flags 😥 

After fixing the regex:
```
[ '--experimental-extras',
  '--use-strict',
  '--es-staging',
  '--harmony',
  '--harmony-shipping',
  '--harmony-array-prototype-values',
  '--harmony-do-expressions',
  ... ]
```
I added a test to look for duplicates. I can't think of better test 🤔