### PR TITLE
Support node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
   - '5'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     - nodejs_version: "5"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "10"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/index.js
+++ b/index.js
@@ -60,6 +60,14 @@ function tryOpenConfig (configpath, cb) {
   }
 }
 
+// Node <= 9 outputs _ in flags with multiple words, while node 10
+// uses -. Both ways are accepted anyway, so always use `_` for better
+// compatibility.
+// We must not replace the first two --.
+function normalizeFlagName(flag) {
+  return "--" + flag.slice(4).replace(/-/g, "_");
+}
+
 // i can't wait for the day this whole module is obsolete because these
 // options are available on the process object. this executes node with
 // `--v8-options` and parses the result, returning an array of command
@@ -69,11 +77,11 @@ function getFlags (cb) {
     if (execErr) {
       return cb(execErr);
     }
-    var flags = result.match(/\s\s--(\w+)/gm).map(function (match) {
-      return match.substring(2);
-    }).filter(function (name) {
-      return exclusions.indexOf(name) === -1;
-    });
+    var flags = result.match(/\s\s--[\w-]+/gm)
+      .map(normalizeFlagName)
+      .filter(function (name) {
+        return exclusions.indexOf(name) === -1;
+      });
     return cb(null, flags);
   });
 }

--- a/test.js
+++ b/test.js
@@ -128,7 +128,9 @@ describe('v8flags', function () {
     });
   });
 
-  it('should handle undefined usernames', function(done) {
+  it('should handle option names with multiple words', function(done) {
+    if (parseInt(process.versions.node) < 4) return;
+
     eraseHome();
     const v8flags = require('./');
     v8flags(function (err, flags) {
@@ -137,7 +139,7 @@ describe('v8flags', function () {
     });
   });
 
-  it('should handle option names with multiple words', function(done) {
+  it('should handle undefined usernames', function(done) {
     eraseHome();
     const v8flags = require('./');
     v8flags(function (err, flags) {

--- a/test.js
+++ b/test.js
@@ -129,7 +129,7 @@ describe('v8flags', function () {
   });
 
   it('should handle option names with multiple words', function(done) {
-    if (parseInt(process.versions.node) < 4) return;
+    if (parseInt(process.versions.node) < 4) return done();
 
     eraseHome();
     const v8flags = require('./');

--- a/test.js
+++ b/test.js
@@ -132,6 +132,15 @@ describe('v8flags', function () {
     eraseHome();
     const v8flags = require('./');
     v8flags(function (err, flags) {
+      expect(flags).to.include("--expose_gc_as");
+      done();
+    });
+  });
+
+  it('should handle option names with multiple words', function(done) {
+    eraseHome();
+    const v8flags = require('./');
+    v8flags(function (err, flags) {
       expect(err).to.be.null;
       done();
     });


### PR DESCRIPTION
Commit message:

> Support node 10
>
> In node <= 9, `node --v8-options` returned a list
> of options formatted like `--expose_gc_as`.
> In node 10, it formats them like  `--expose-gc-as`.

Context:
I found this bug because Babel's tests are currently broken on node 10 :stuck_out_tongue: 