### PR TITLE
Add package version to the cache file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,12 @@ const path = require('path');
 const crypto = require('crypto');
 const execFile = require('child_process').execFile;
 const configPath = require('./config-path.js')(process.platform);
+const version = require("./package.json").version;
 const env = process.env;
 const user = env.LOGNAME || env.USER || env.LNAME || env.USERNAME || '';
 const exclusions = ['--help'];
 
-const configfile = '.v8flags.'+process.versions.v8+'.'+crypto.createHash('md5').update(user).digest('hex')+'.json';
+const configfile = '.v8flags-'+version+'-'+process.versions.v8+'.'+crypto.createHash('md5').update(user).digest('hex')+'.json';
 
 const failureMessage = [
   'Unable to cache a config file for v8flags to your home directory',

--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ const env = process.env;
 const user = env.LOGNAME || env.USER || env.LNAME || env.USERNAME || '';
 const exclusions = ['--help'];
 
-const configfile = '.v8flags-'+version+'-'+process.versions.v8+'.'+crypto.createHash('md5').update(user).digest('hex')+'.json';
+// This number must be incremented whenever the generated cache file changes.
+const CACHE_VERSION = 1;
+
+const configfile = '.v8flags-'+CACHE_VERSION+'-'+process.versions.v8+'.'+crypto.createHash('md5').update(user).digest('hex')+'.json';
 
 const failureMessage = [
   'Unable to cache a config file for v8flags to your home directory',

--- a/test.js
+++ b/test.js
@@ -74,13 +74,6 @@ describe('v8flags', function () {
     });
   });
 
-  it('should cache based on the package version', function (done) {
-    const v8flags = require('./');
-    const version = require('./package.json').version;
-    expect(v8flags.configfile).to.contain(version);
-    done();
-  })
-
   it('should not append the file when multiple calls happen concurrently and the config file does not yet exist', function (done) {
     const v8flags = require('./');
     const configfile = path.resolve(v8flags.configPath, v8flags.configfile);

--- a/test.js
+++ b/test.js
@@ -74,6 +74,13 @@ describe('v8flags', function () {
     });
   });
 
+  it('should cache based on the package version', function (done) {
+    const v8flags = require('./');
+    const version = require('./package.json').version;
+    expect(v8flags.configfile).to.contain(version);
+    done();
+  })
+
   it('should not append the file when multiple calls happen concurrently and the config file does not yet exist', function (done) {
     const v8flags = require('./');
     const configfile = path.resolve(v8flags.configPath, v8flags.configfile);


### PR DESCRIPTION
Even if I updated this package to he new version in Babel (https://github.com/babel/babel/pull/7908), it still shows the error it showed with v3.0.2.
I spent some time debugging it (= I wrote random things trying to make it work :rofl:), then I found a module deep in our dependency graph which relies on `v8flags@3.0.1`. We use that package while building Babel, so it is run _before_ Babel's tests. It generates a cache file with the bugged flags, which is then loaded by `v8flags@3.1.0`.

I will update the dependency of that package, but this PR
1) Will prevent prolems like this in the future
2) Makes the life easier for people affected by this bug, since they won't have to wait their dependencies to be upgradet.