### PR TITLE
fix: Exclude example flags provided by node

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,8 +91,8 @@ function getFlags(cb) {
 
     var index = result.indexOf('\nOptions:');
     if (index >= 0) {
+      result = result.slice(index);
       var regexp = /^\s\s--[\w-]+/gm;
-      regexp.lastIndex = index;
       var matchedFlags = result.match(regexp);
       if (matchedFlags) {
         flags = flags.concat(

--- a/test/index.js
+++ b/test/index.js
@@ -225,6 +225,16 @@ describe('v8flags', function () {
       done();
     });
   });
+
+  it('does not detect nodejs example flags', function (done) {
+    eraseHome();
+    var v8flags = require('../');
+    v8flags(function (err, flags) {
+      expect(flags).not.toContain('--flag');
+      expect(flags).not.toContain('--no-flag');
+      done();
+    });
+  });
 });
 
 describe('config-path', function () {


### PR DESCRIPTION
This PR is to fix the issue #65.

In recent Node.js, the output of `node --v8-options` contains extra lines in the `--xxx` format, like:
```
% node --v8-options
SSE3=1 SSSE3=1 SSE4_1=1 SSE4_2=1 SAHF=1 AVX=1 AVX2=1 FMA3=1 BMI1=1 BMI2=1 LZCNT=1 POPCNT=1 ATOM=0
The following syntax for options is accepted (both '-' and '--' are ok):
  --flag        (bool flags only)
  --no-flag     (bool flags only)
  --flag=value  (non-bool flags only, no spaces around '=')
  --flag value  (non-bool flags only)
  --            (captures all remaining args in JavaScript)

Options:
  --abort-on-contradictory-flags (Disallow flags or implications overriding each other.)
        type: bool  default: --noabort-on-contradictory-flags
  ...
```

Regarding this issue, we had implemented a solution to extract options from `Options:` onward, but there was a mistake in that. This PR is to correct that mistake. 

Closes #65 