### PR TITLE
chore(ci): Ensure fake-bin test case runs on newer node versions

### DIFF
--- a/test/fake-bin
+++ b/test/fake-bin
@@ -1,0 +1,1 @@
+#!/usr/bin/env node


### PR DESCRIPTION
This PR fixes an error caused in a test case.
This error can be seen [here](https://github.com/sttk/v8flags/actions/runs/6063160767). As shown there, this error is caused on Node.js 18 or later, and only on macOS.